### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/dari-core/build.gradle.kts
+++ b/dari-core/build.gradle.kts
@@ -23,7 +23,7 @@ mavenPublishing {
     coordinates(
         groupId = "io.github.easyhooon",
         artifactId = "dari-core",
-        version = "1.1.1"
+        version = "1.2.0"
     )
 
     pom {

--- a/dari-noop/build.gradle.kts
+++ b/dari-noop/build.gradle.kts
@@ -32,7 +32,7 @@ mavenPublishing {
     coordinates(
         groupId = "io.github.easyhooon",
         artifactId = "dari-noop",
-        version = "1.1.1"
+        version = "1.2.0"
     )
 
     pom {

--- a/dari/build.gradle.kts
+++ b/dari/build.gradle.kts
@@ -66,7 +66,7 @@ mavenPublishing {
     coordinates(
         groupId = "io.github.easyhooon",
         artifactId = "dari",
-        version = "1.1.1"
+        version = "1.2.0"
     )
 
     pom {

--- a/dari/src/androidTest/kotlin/com/easyhooon/dari/data/MessageRepositoryTest.kt
+++ b/dari/src/androidTest/kotlin/com/easyhooon/dari/data/MessageRepositoryTest.kt
@@ -23,6 +23,8 @@ class MessageRepositoryTest {
 
     @Before
     fun setup() {
+        // Uses in-memory database (not persisted to disk) for test isolation.
+        // Automatically garbage-collected when the test instance is discarded.
         database = Room.inMemoryDatabaseBuilder(
             ApplicationProvider.getApplicationContext(),
             DariDatabase::class.java,
@@ -32,6 +34,9 @@ class MessageRepositoryTest {
 
     @After
     fun tearDown() {
+        // Only cancel the coroutine scope; do NOT call database.close() here.
+        // The repository's background scope may still be executing DAO operations,
+        // and closing the database would cause SQLiteDatabase already-closed crashes.
         repository.close()
     }
 


### PR DESCRIPTION
## Summary
- Bump all module versions (dari, dari-core, dari-noop) from 1.1.1 to 1.2.0 for the Room persistence release
- Add clarifying comments to test setup/tearDown explaining in-memory DB usage and why `database.close()` is omitted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped library version to 1.2.0 across all core modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->