### PR TITLE
feat: declutter message list top bar (5 → 3 actions)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,12 @@
 
 - Do NOT include `Co-Authored-By` lines referencing Claude in commit messages.
 - Do NOT include "Generated with Claude Code" or similar AI attribution in PR descriptions.
+- **Keep commit messages compact.** Subject ≤ 72 chars. Body only when the "why" isn't obvious from the diff — 1–3 short lines, no multi-paragraph essays. Don't restate what the diff already shows.
+
+## Code Style
+
+- Do NOT use fully-qualified names (FQN) inline in Kotlin code. Always add a proper `import` statement at the top of the file and reference the type by its simple name. This applies to both production and test code.
+- **Keep comments compact.** Explain non-obvious intent in one or two lines. No multi-paragraph KDoc unless the API is genuinely complex. Skip comments that just restate the code.
 
 ## Code Style
 

--- a/dari-core/build.gradle.kts
+++ b/dari-core/build.gradle.kts
@@ -27,7 +27,7 @@ mavenPublishing {
     coordinates(
         groupId = "io.github.easyhooon",
         artifactId = "dari-core",
-        version = "1.3.3",
+        version = libs.versions.dari.get(),
     )
 
     pom {

--- a/dari/src/main/kotlin/com/easyhooon/dari/ui/DariActivity.kt
+++ b/dari/src/main/kotlin/com/easyhooon/dari/ui/DariActivity.kt
@@ -26,14 +26,13 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.IosShare
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -156,8 +155,7 @@ class DariActivity : ComponentActivity() {
                 var selectedTag by rememberSaveable { mutableStateOf<String?>(null) }
                 var selectedStatus by rememberSaveable { mutableStateOf<MessageStatus?>(null) }
                 var showClearDialog by rememberSaveable { mutableStateOf(false) }
-                var shareMenuExpanded by remember { mutableStateOf(false) }
-                var downloadMenuExpanded by remember { mutableStateOf(false) }
+                var exportMenuExpanded by remember { mutableStateOf(false) }
                 var showSettingsSheet by rememberSaveable { mutableStateOf(false) }
                 val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -246,19 +244,19 @@ class DariActivity : ComponentActivity() {
                                 }
                                 Box {
                                     IconButton(
-                                        onClick = { shareMenuExpanded = true },
+                                        onClick = { exportMenuExpanded = true },
                                         enabled = filteredEntries.isNotEmpty(),
                                     ) {
-                                        Icon(Icons.Default.Share, contentDescription = "Share")
+                                        Icon(Icons.Default.IosShare, contentDescription = "Export")
                                     }
                                     DropdownMenu(
-                                        expanded = shareMenuExpanded,
-                                        onDismissRequest = { shareMenuExpanded = false },
+                                        expanded = exportMenuExpanded,
+                                        onDismissRequest = { exportMenuExpanded = false },
                                     ) {
                                         DropdownMenuItem(
                                             text = { Text("Share as TEXT") },
                                             onClick = {
-                                                shareMenuExpanded = false
+                                                exportMenuExpanded = false
                                                 lifecycleScope.launch {
                                                     DariExporter.exportAndShare(
                                                         this@DariActivity,
@@ -271,7 +269,7 @@ class DariActivity : ComponentActivity() {
                                         DropdownMenuItem(
                                             text = { Text("Share as JSON") },
                                             onClick = {
-                                                shareMenuExpanded = false
+                                                exportMenuExpanded = false
                                                 lifecycleScope.launch {
                                                     DariExporter.exportAndShare(
                                                         this@DariActivity,
@@ -281,37 +279,22 @@ class DariActivity : ComponentActivity() {
                                                 }
                                             },
                                         )
-                                    }
-                                }
-                                Box {
-                                    IconButton(
-                                        onClick = { downloadMenuExpanded = true },
-                                        enabled = filteredEntries.isNotEmpty(),
-                                    ) {
-                                        Icon(Icons.Default.Download, contentDescription = "Save")
-                                    }
-                                    DropdownMenu(
-                                        expanded = downloadMenuExpanded,
-                                        onDismissRequest = { downloadMenuExpanded = false },
-                                    ) {
+                                        HorizontalDivider()
                                         DropdownMenuItem(
                                             text = { Text("Save as TEXT") },
                                             onClick = {
-                                                downloadMenuExpanded = false
+                                                exportMenuExpanded = false
                                                 launchSave(filteredEntries, ExportFormat.TEXT)
                                             },
                                         )
                                         DropdownMenuItem(
                                             text = { Text("Save as JSON") },
                                             onClick = {
-                                                downloadMenuExpanded = false
+                                                exportMenuExpanded = false
                                                 launchSave(filteredEntries, ExportFormat.JSON)
                                             },
                                         )
                                     }
-                                }
-                                IconButton(onClick = { showClearDialog = true }) {
-                                    Icon(Icons.Default.Delete, contentDescription = "Clear")
                                 }
                                 IconButton(onClick = { showSettingsSheet = true }) {
                                     Icon(Icons.Default.Settings, contentDescription = "Settings")
@@ -412,6 +395,10 @@ class DariActivity : ComponentActivity() {
                             onShakeToOpenChange = { Dari.setShakeToOpenEnabled(it) },
                             darkMode = darkMode,
                             onDarkModeChange = { Dari.setDarkMode(it) },
+                            onClearMessages = {
+                                showSettingsSheet = false
+                                showClearDialog = true
+                            },
                             onDismiss = { showSettingsSheet = false },
                         )
                     }

--- a/dari/src/main/kotlin/com/easyhooon/dari/ui/components/SettingsBottomSheet.kt
+++ b/dari/src/main/kotlin/com/easyhooon/dari/ui/components/SettingsBottomSheet.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.Brightness6
+import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Vibration
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -52,6 +53,7 @@ internal fun SettingsBottomSheet(
     onShakeToOpenChange: (Boolean) -> Unit,
     darkMode: Boolean?,
     onDarkModeChange: (Boolean?) -> Unit,
+    onClearMessages: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -87,6 +89,19 @@ internal fun SettingsBottomSheet(
             DarkModeRow(
                 darkMode = darkMode,
                 onDarkModeChange = onDarkModeChange,
+            )
+
+            HorizontalDivider(
+                modifier = Modifier.padding(vertical = 12.dp),
+                color = MaterialTheme.colorScheme.outlineVariant,
+            )
+
+            SectionHeader("Data")
+            DestructiveActionRow(
+                icon = Icons.Default.DeleteOutline,
+                title = "Clear all messages",
+                description = "Permanently remove every captured bridge message",
+                onClick = onClearMessages,
             )
 
             HorizontalDivider(
@@ -237,6 +252,55 @@ private fun SettingToggleRow(
                 checkedTrackColor = DariBlue,
             ),
         )
+    }
+}
+
+@Composable
+private fun DestructiveActionRow(
+    icon: ImageVector,
+    title: String,
+    description: String,
+    onClick: () -> Unit,
+) {
+    val accent = MaterialTheme.colorScheme.error
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 24.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(accent.copy(alpha = 0.12f)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = accent,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+        Spacer(Modifier.size(16.dp))
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                color = accent,
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-dari = "1.3.3"
+dari = "1.4.0"
 agp = "9.0.0"
 coreKtx = "1.17.0"
 junit = "4.13.2"


### PR DESCRIPTION
## Summary

Top bar: Search · Share · Download · Clear · Settings **→** Search · Export · Settings.

- Share + Download merged into one Export dropdown (Share TEXT/JSON + divider + Save TEXT/JSON). Export flows unchanged.
- Clear moved into the settings sheet (Data section) with destructive styling via `MaterialTheme.colorScheme.error`. Still raises the same confirmation dialog.

Closes #38.

## Test plan

- [x] `./gradlew :dari:compileDebugKotlin`
- [x] Smoke: Export dropdown shows 4 items and all paths still share/save correctly
- [x] Smoke: Clear from settings sheet closes the sheet and opens the confirm dialog
- [x] Smoke: Search field width feels comfortable with only 3 actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consolidated Share and Save into a single Export menu with options: share as TEXT/JSON and save as TEXT/JSON.
  * Moved "Clear all messages" into a new Data section in Settings (replaces top-bar Clear action).

* **Documentation**
  * Updated project guidelines: compact commit subject/body rules and concise Kotlin code style/commenting guidance.

* **Chores**
  * Project version reference updated to 1.4.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->