### PR TITLE
fix: improve shake detection with direction-reversal algorithm

### DIFF
--- a/dari/src/main/kotlin/com/easyhooon/dari/shake/ShakeDetector.kt
+++ b/dari/src/main/kotlin/com/easyhooon/dari/shake/ShakeDetector.kt
@@ -8,46 +8,106 @@ import android.hardware.SensorManager
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
-import kotlin.math.sqrt
-
-internal const val SHAKE_THRESHOLD_G = 2.5f
-internal const val SHAKE_COOLDOWN_MS = 1000L
+import kotlin.math.abs
 
 /** Standard gravity in m/s^2. Hardcoded so the analyzer is testable without Android framework. */
 internal const val GRAVITY_EARTH_MS2 = 9.80665f
 
+/** Force threshold per axis: 1.33G (same as React Native ShakeDetector). */
+internal const val SHAKE_FORCE_THRESHOLD = GRAVITY_EARTH_MS2 * 1.33f
+
+/** Number of direction reversals required to trigger a shake. */
+internal const val REQUIRED_REVERSALS = 8
+
+/** Rolling time window in which reversals must occur (ms). */
+internal const val SHAKE_WINDOW_MS = 3_000L
+
+/** Cooldown after a successful shake detection (ms). */
+internal const val SHAKE_COOLDOWN_MS = 1_000L
+
+/** Minimum time between sensor samples to avoid over-processing (ms). */
+internal const val MIN_SAMPLE_INTERVAL_MS = 20L
+
 /**
- * Pure shake detection logic. Holds the cooldown state but has no Android dependencies,
- * so it can be unit tested without mocking sensors.
+ * Shake detection using per-axis direction reversal counting,
+ * inspired by React Native's ShakeDetector.
+ *
+ * A direction reversal is counted when acceleration on any axis exceeds
+ * [SHAKE_FORCE_THRESHOLD] and the sign flips from the previous reading.
+ * When [requiredReversals] reversals accumulate within [windowMs],
+ * a shake is detected.
  */
 internal class ShakeAnalyzer(
-    private val thresholdG: Float = SHAKE_THRESHOLD_G,
+    private val forceThreshold: Float = SHAKE_FORCE_THRESHOLD,
+    private val requiredReversals: Int = REQUIRED_REVERSALS,
+    private val windowMs: Long = SHAKE_WINDOW_MS,
     private val cooldownMs: Long = SHAKE_COOLDOWN_MS,
+    private val minSampleIntervalMs: Long = MIN_SAMPLE_INTERVAL_MS,
 ) {
-    private var lastShakeTime = 0L
-    private var hasShaken = false
+    private var prevX = 0f
+    private var prevY = 0f
+    private var prevZ = 0f
+    private var reversalCount = 0
+    private var firstReversalMs = 0L
+    private var lastReversalMs = 0L
+    private var lastShakeMs = 0L
+    private var lastSampleMs = -1L
 
     /**
-     * Returns true if the given accelerometer reading represents a shake event,
-     * accounting for cooldown since the last detected shake.
+     * Feed an accelerometer reading. Returns true when a shake gesture is detected.
      *
-     * @param x acceleration on the X axis in m/s^2
-     * @param y acceleration on the Y axis in m/s^2
-     * @param z acceleration on the Z axis in m/s^2
-     * @param nowMs current time in milliseconds
+     * Z-axis has gravity subtracted so a resting device does not produce false positives.
      */
     fun onAcceleration(x: Float, y: Float, z: Float, nowMs: Long): Boolean {
-        val gX = x / GRAVITY_EARTH_MS2
-        val gY = y / GRAVITY_EARTH_MS2
-        val gZ = z / GRAVITY_EARTH_MS2
-        val gForce = sqrt(gX * gX + gY * gY + gZ * gZ)
+        if (lastSampleMs >= 0L && nowMs - lastSampleMs < minSampleIntervalMs) return false
+        lastSampleMs = nowMs
 
-        if (gForce <= thresholdG) return false
-        if (hasShaken && nowMs - lastShakeTime <= cooldownMs) return false
+        if (nowMs - lastShakeMs < cooldownMs && lastShakeMs > 0L) return false
 
-        hasShaken = true
-        lastShakeTime = nowMs
-        return true
+        val az = z - GRAVITY_EARTH_MS2
+
+        var reversed = false
+
+        if (abs(x) >= forceThreshold && x * prevX <= 0) {
+            reversed = true
+            prevX = x
+        }
+        if (abs(y) >= forceThreshold && y * prevY <= 0) {
+            reversed = true
+            prevY = y
+        }
+        if (abs(az) >= forceThreshold && az * prevZ <= 0) {
+            reversed = true
+            prevZ = az
+        }
+
+        if (!reversed) return false
+
+        if (reversalCount == 0) {
+            firstReversalMs = nowMs
+        }
+
+        reversalCount++
+        lastReversalMs = nowMs
+
+        if (nowMs - firstReversalMs > windowMs) {
+            reset()
+            return false
+        }
+
+        if (reversalCount >= requiredReversals) {
+            lastShakeMs = nowMs
+            reset()
+            return true
+        }
+
+        return false
+    }
+
+    private fun reset() {
+        reversalCount = 0
+        firstReversalMs = 0L
+        lastReversalMs = 0L
     }
 }
 

--- a/dari/src/test/kotlin/com/easyhooon/dari/shake/ShakeAnalyzerTest.kt
+++ b/dari/src/test/kotlin/com/easyhooon/dari/shake/ShakeAnalyzerTest.kt
@@ -6,69 +6,149 @@ import org.junit.Test
 
 class ShakeAnalyzerTest {
 
-    private val gravity = GRAVITY_EARTH_MS2
+    private val g = GRAVITY_EARTH_MS2
+    private val force = SHAKE_FORCE_THRESHOLD + 1f
+
+    /**
+     * Simulates alternating force readings on the X axis.
+     * With `<= 0` sign check (matching React Native), the very first strong
+     * reading counts as a reversal because `prevX` starts at 0.
+     * Each subsequent sign flip also counts as one reversal.
+     */
+    private fun feedReversals(analyzer: ShakeAnalyzer, count: Int, startMs: Long): Long {
+        var t = startMs
+        for (i in 0 until count) {
+            val v = if (i % 2 == 0) force else -force
+            analyzer.onAcceleration(v, 0f, g, t)
+            t += 50
+        }
+        return t
+    }
 
     @Test
-    fun `still device at 1g does not register a shake`() {
+    fun `still device does not register a shake`() {
         val analyzer = ShakeAnalyzer()
-        // Phone resting flat: y axis ~= 1g, others 0
-        assertFalse(analyzer.onAcceleration(0f, gravity, 0f, nowMs = 0L))
+        assertFalse(analyzer.onAcceleration(0f, g, 0f, nowMs = 0L))
     }
 
     @Test
-    fun `acceleration above threshold registers a shake`() {
+    fun `single spike does not register a shake`() {
         val analyzer = ShakeAnalyzer()
-        // 3g on a single axis
-        assertTrue(analyzer.onAcceleration(3 * gravity, 0f, 0f, nowMs = 0L))
+        // 1 reversal is not enough (need 8)
+        assertFalse(analyzer.onAcceleration(3 * g, 0f, g, nowMs = 0L))
     }
 
     @Test
-    fun `acceleration just below threshold does not register`() {
-        val analyzer = ShakeAnalyzer(thresholdG = 2.5f)
-        // 2g - below 2.5g threshold
-        assertFalse(analyzer.onAcceleration(2 * gravity, 0f, 0f, nowMs = 0L))
+    fun `full shake cycle triggers after required reversals`() {
+        val analyzer = ShakeAnalyzer(requiredReversals = 4)
+        var t = 0L
+        // 3 reversals — not enough
+        t = feedReversals(analyzer, 3, t)
+        // 4th reversal → trigger
+        assertTrue(analyzer.onAcceleration(-force, 0f, g, t))
     }
 
     @Test
-    fun `combined axes contribute to total g-force`() {
+    fun `default 8 reversals required`() {
         val analyzer = ShakeAnalyzer()
-        // sqrt(2^2 + 2^2 + 2^2) ~ 3.46g
-        assertTrue(
-            analyzer.onAcceleration(2 * gravity, 2 * gravity, 2 * gravity, nowMs = 0L),
-        )
+        var t = 0L
+        // 7 reversals — not enough
+        t = feedReversals(analyzer, 7, t)
+        // 8th reversal → trigger
+        assertTrue(analyzer.onAcceleration(-force, 0f, g, t))
     }
 
     @Test
-    fun `second shake within cooldown is ignored`() {
-        val analyzer = ShakeAnalyzer(cooldownMs = 1000L)
-        assertTrue(analyzer.onAcceleration(3 * gravity, 0f, 0f, nowMs = 0L))
-        // 500 ms later, still inside cooldown
-        assertFalse(analyzer.onAcceleration(3 * gravity, 0f, 0f, nowMs = 500L))
+    fun `reversals outside time window are reset`() {
+        val analyzer = ShakeAnalyzer(requiredReversals = 6, windowMs = 3_000L)
+        var t = 0L
+        // 3 reversals
+        t = feedReversals(analyzer, 3, t)
+        // Jump past window
+        t += 4_000L
+        // New window: 5 reversals — not enough (need 6, prev 3 were reset)
+        t = feedReversals(analyzer, 5, t)
+        assertFalse(analyzer.onAcceleration(force, 0f, g, t))
     }
 
     @Test
-    fun `second shake after cooldown is registered`() {
-        val analyzer = ShakeAnalyzer(cooldownMs = 1000L)
-        assertTrue(analyzer.onAcceleration(3 * gravity, 0f, 0f, nowMs = 0L))
-        // 1500 ms later, past cooldown
-        assertTrue(analyzer.onAcceleration(3 * gravity, 0f, 0f, nowMs = 1500L))
+    fun `cooldown prevents immediate re-trigger`() {
+        val analyzer = ShakeAnalyzer(requiredReversals = 4, cooldownMs = 1_000L)
+        var t = 0L
+        // Trigger first shake (4 reversals)
+        t = feedReversals(analyzer, 3, t)
+        assertTrue(analyzer.onAcceleration(-force, 0f, g, t))
+        t += 50
+
+        // Within cooldown — all readings should be rejected
+        for (i in 0 until 8) {
+            val v = if (i % 2 == 0) force else -force
+            assertFalse(analyzer.onAcceleration(v, 0f, g, t))
+            t += 50
+        }
     }
 
     @Test
-    fun `cooldown is not triggered by sub-threshold readings`() {
-        val analyzer = ShakeAnalyzer(cooldownMs = 1000L)
-        // Sub-threshold reading should not start a cooldown
-        assertFalse(analyzer.onAcceleration(0f, gravity, 0f, nowMs = 0L))
-        // A real shake right after should still register
-        assertTrue(analyzer.onAcceleration(3 * gravity, 0f, 0f, nowMs = 100L))
+    fun `shake registers after cooldown expires`() {
+        val analyzer = ShakeAnalyzer(requiredReversals = 4, cooldownMs = 1_000L)
+        var t = 0L
+        // Trigger first shake
+        t = feedReversals(analyzer, 3, t)
+        assertTrue(analyzer.onAcceleration(-force, 0f, g, t))
+
+        // Wait past cooldown
+        t += 1_500L
+
+        // Should trigger again
+        t = feedReversals(analyzer, 3, t)
+        assertTrue(analyzer.onAcceleration(-force, 0f, g, t))
     }
 
     @Test
-    fun `custom threshold is respected`() {
-        val analyzer = ShakeAnalyzer(thresholdG = 4.0f)
-        // 3g - below custom 4g threshold
-        assertFalse(analyzer.onAcceleration(3 * gravity, 0f, 0f, nowMs = 0L))
-        // 5g - above custom threshold
-        assertTrue(analyzer.onAcceleration(5 * gravity, 0f, 0f, nowMs = 0L))
+    fun `sub-threshold readings do not count as reversals`() {
+        val analyzer = ShakeAnalyzer()
+        val weak = SHAKE_FORCE_THRESHOLD * 0.5f
+        var t = 0L
+        for (i in 0 until 20) {
+            assertFalse(analyzer.onAcceleration(weak, 0f, g, t))
+            t += 50
+            assertFalse(analyzer.onAcceleration(-weak, 0f, g, t))
+            t += 50
+        }
+    }
+
+    @Test
+    fun `samples within minimum interval are ignored`() {
+        val analyzer = ShakeAnalyzer(minSampleIntervalMs = 20L)
+        assertFalse(analyzer.onAcceleration(force, 0f, g, nowMs = 0L))
+        // 5ms later — too soon, ignored
+        assertFalse(analyzer.onAcceleration(-force, 0f, g, nowMs = 5L))
+        // 25ms later — accepted
+        assertFalse(analyzer.onAcceleration(-force, 0f, g, nowMs = 25L))
+    }
+
+    @Test
+    fun `y-axis reversals also count`() {
+        val analyzer = ShakeAnalyzer(requiredReversals = 4)
+        var t = 0L
+        // Feed 3 reversals on Y axis
+        for (i in 0 until 3) {
+            val v = if (i % 2 == 0) force else -force
+            analyzer.onAcceleration(0f, v, g, t)
+            t += 50
+        }
+        // 4th reversal → trigger
+        assertTrue(analyzer.onAcceleration(0f, -force, g, t))
+    }
+
+    @Test
+    fun `custom required reversals is respected`() {
+        val analyzer = ShakeAnalyzer(requiredReversals = 2)
+        var t = 0L
+        // 1st reversal
+        assertFalse(analyzer.onAcceleration(force, 0f, g, t))
+        t += 50
+        // 2nd reversal → trigger
+        assertTrue(analyzer.onAcceleration(-force, 0f, g, t))
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-dari = "1.4.0"
+dari = "1.4.1"
 agp = "9.0.0"
 coreKtx = "1.17.0"
 junit = "4.13.2"


### PR DESCRIPTION
## Summary

- Replace single acceleration spike detection (2.5G, 1 event) with direction-reversal counting algorithm inspired by [React Native's ShakeDetector](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/ShakeDetector.kt)
- Require 8 axis direction reversals within a 3-second window (~4 physical shakes) to trigger
- Add gravity compensation on Z-axis to prevent false positives when device is resting
- Add minimum 20ms sampling interval to avoid over-processing

| Parameter | Before | After |
|---|---|---|
| Algorithm | Single magnitude spike | Per-axis direction reversal |
| Force threshold | 2.5G | 1.33G |
| Events to trigger | 1 spike | 8 reversals (~4 shakes) |
| Time window | N/A (cooldown only) | 3 seconds |
| Gravity compensation | None | Z-axis subtracted |

## Test plan

- [x] Shake device gently once → should NOT open inspector
- [x] Shake device vigorously 4+ times within 3 seconds → should open inspector
- [ ] Verify all unit tests pass (`./gradlew :dari:test`)

Closes #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shake detection to recognize axis direction reversals for more accurate shake triggering.
  * Added sensor reading throttling to eliminate false positives from rapid fluctuations.
  * Refined cooldown logic to prevent accidental re-triggering of shake events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->