### PR TITLE
fix: improve dialog button contrast in dark mode

### DIFF
--- a/dari/src/main/kotlin/com/easyhooon/dari/ui/DariActivity.kt
+++ b/dari/src/main/kotlin/com/easyhooon/dari/ui/DariActivity.kt
@@ -72,6 +72,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import com.easyhooon.dari.ui.components.MessageListItem
 import com.easyhooon.dari.ui.components.SettingsBottomSheet
 import com.easyhooon.dari.ui.theme.ApplyDariSystemBars
+import com.easyhooon.dari.ui.theme.DariBlue
 import com.easyhooon.dari.ui.theme.DariTheme
 import com.easyhooon.dari.ui.theme.DariTopBarColors
 import com.easyhooon.dari.ui.theme.palette
@@ -413,12 +414,12 @@ class DariActivity : ComponentActivity() {
                                     Dari.clear()
                                     showClearDialog = false
                                 }) {
-                                    Text("CLEAR")
+                                    Text("CLEAR", color = DariBlue)
                                 }
                             },
                             dismissButton = {
                                 TextButton(onClick = { showClearDialog = false }) {
-                                    Text("CANCEL")
+                                    Text("CANCEL", color = DariBlue)
                                 }
                             },
                         )

--- a/dari/src/main/kotlin/com/easyhooon/dari/ui/DariActivity.kt
+++ b/dari/src/main/kotlin/com/easyhooon/dari/ui/DariActivity.kt
@@ -72,7 +72,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import com.easyhooon.dari.ui.components.MessageListItem
 import com.easyhooon.dari.ui.components.SettingsBottomSheet
 import com.easyhooon.dari.ui.theme.ApplyDariSystemBars
-import com.easyhooon.dari.ui.theme.DariBlue
+import com.easyhooon.dari.ui.theme.Blue500
 import com.easyhooon.dari.ui.theme.DariTheme
 import com.easyhooon.dari.ui.theme.DariTopBarColors
 import com.easyhooon.dari.ui.theme.palette
@@ -414,12 +414,12 @@ class DariActivity : ComponentActivity() {
                                     Dari.clear()
                                     showClearDialog = false
                                 }) {
-                                    Text("CLEAR", color = DariBlue)
+                                    Text("CLEAR", color = Blue500)
                                 }
                             },
                             dismissButton = {
                                 TextButton(onClick = { showClearDialog = false }) {
-                                    Text("CANCEL", color = DariBlue)
+                                    Text("CANCEL", color = Blue500)
                                 }
                             },
                         )

--- a/dari/src/main/kotlin/com/easyhooon/dari/ui/components/SettingsBottomSheet.kt
+++ b/dari/src/main/kotlin/com/easyhooon/dari/ui/components/SettingsBottomSheet.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import com.easyhooon.dari.BuildConfig
-import com.easyhooon.dari.ui.theme.DariBlue
+import com.easyhooon.dari.ui.theme.Blue500
 
 private const val GITHUB_URL = "https://github.com/easyhooon/dari"
 
@@ -132,7 +132,7 @@ private fun SectionHeader(text: String) {
     Text(
         text = text.uppercase(),
         style = MaterialTheme.typography.labelMedium,
-        color = DariBlue,
+        color = Blue500,
         fontWeight = FontWeight.SemiBold,
         modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
     )
@@ -161,13 +161,13 @@ private fun DarkModeRow(
             modifier = Modifier
                 .size(40.dp)
                 .clip(CircleShape)
-                .background(DariBlue.copy(alpha = 0.12f)),
+                .background(Blue500.copy(alpha = 0.12f)),
             contentAlignment = Alignment.Center,
         ) {
             Icon(
                 imageVector = Icons.Default.Brightness6,
                 contentDescription = null,
-                tint = DariBlue,
+                tint = Blue500,
                 modifier = Modifier.size(20.dp),
             )
         }
@@ -218,13 +218,13 @@ private fun SettingToggleRow(
             modifier = Modifier
                 .size(40.dp)
                 .clip(CircleShape)
-                .background(DariBlue.copy(alpha = 0.12f)),
+                .background(Blue500.copy(alpha = 0.12f)),
             contentAlignment = Alignment.Center,
         ) {
             Icon(
                 imageVector = icon,
                 contentDescription = null,
-                tint = DariBlue,
+                tint = Blue500,
                 modifier = Modifier.size(20.dp),
             )
         }
@@ -249,7 +249,7 @@ private fun SettingToggleRow(
             onCheckedChange = onCheckedChange,
             colors = SwitchDefaults.colors(
                 checkedThumbColor = Color.White,
-                checkedTrackColor = DariBlue,
+                checkedTrackColor = Blue500,
             ),
         )
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-dari = "1.4.1"
+dari = "1.4.2"
 agp = "9.0.0"
 coreKtx = "1.17.0"
 junit = "4.13.2"


### PR DESCRIPTION
## Summary

- Use `DariBlue` (`#2D6AB1`) instead of theme `primary` (`DariBlueDark` / `#1F4F87`) for Clear dialog button text, ensuring readability on dark surfaces

## Note

The bottom sheet also uses `DariBlue` for section headers and icon tints — these may also need contrast review in dark mode. This PR addresses the dialog buttons only; bottom sheet adjustments can follow if needed.

## Test plan

- [ ] Dark mode → Settings → Clear all messages → verify "CLEAR" and "CANCEL" buttons are clearly readable
- [ ] Light mode → same flow → verify buttons still look correct

Closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visual consistency of the clear confirmation dialog by applying explicit theme coloring to its buttons.

* **Style**
  * Standardized UI accent color across settings and related rows—section headers, icon backgrounds/tints, and switch track styling now use the updated theme color for a more cohesive appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->