### PR TITLE
fix(sample): harden sample WebView settings against file:// XHR escalation (refs #4)

### DIFF
--- a/sample/src/main/java/com/easyhooon/dari/sample/MainActivity.kt
+++ b/sample/src/main/java/com/easyhooon/dari/sample/MainActivity.kt
@@ -57,6 +57,16 @@ class MainActivity : ComponentActivity() {
 
         webView = WebView(this).apply {
             settings.javaScriptEnabled = true
+            // Sample loads from `file:///android_asset/...` and exposes a
+            // JavascriptInterface to the page. Without locking down the
+            // file:// access flags the sample page (or anything that
+            // navigates the WebView) could read other local files via
+            // fetch('file:///...') and reach into other origins. Because
+            // the sample is what people copy-paste, harden it. (CWE-749)
+            settings.allowFileAccess = false
+            settings.allowContentAccess = false
+            settings.allowFileAccessFromFileURLs = false
+            settings.allowUniversalAccessFromFileURLs = false
             webViewClient = WebViewClient()
             addJavascriptInterface(BridgeInterface(), "Android")
             loadUrl("file:///android_asset/sample.html")


### PR DESCRIPTION
## Harden the sample WebView settings (refs #4)

### Scope

Issue #4 is the larger "automatic bridge interception"
design discussion. This PR does **not** attempt that. It
fixes a concrete, smaller problem in the sample app that
the same issue hovers over: the sample is what library
consumers copy-paste, and right now it ships a known-unsafe
WebView configuration.

### The configuration today

```kotlin
webView = WebView(this).apply {
    settings.javaScriptEnabled = true
    webViewClient = WebViewClient()
    addJavascriptInterface(BridgeInterface(), "Android")
    loadUrl("file:///android_asset/sample.html")
}
```

i.e. JavaScript on, a `JavascriptInterface` exposed under
the well-known name `Android`, page loaded from `file://`,
and the four file-access flags left at platform defaults
(true on API < 30). That is CWE-749 / CWE-79 by Google
Play's pre-launch report definition: the sample page can
`fetch('file:///data/data/com.easyhooon.dari.sample/...')`
and exfiltrate the result via the bridge.

### Fix

Add four lines to the same `apply` block:

```kotlin
settings.allowFileAccess = false
settings.allowContentAccess = false
settings.allowFileAccessFromFileURLs = false
settings.allowUniversalAccessFromFileURLs = false
```

The bundled `sample.html` does not need any of these, it
only calls into the bridge, so the sample continues to
demonstrate every dari interceptor flow unchanged.

### Why bundle it under #4

The bridge-interception discussion in #4 keeps coming back
to "can the library do the right thing automatically".
This is one slice of that: it sets the safe defaults the
sample (and therefore most consumers) end up shipping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebView security by restricting access to local files and content resources. The sample application's ability to read other local files through file:// URLs and fetch operations has been limited, enhancing protection against potential security vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->