### PR TITLE
chore: bump version to 1.4.5

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-dari = "1.4.4"
+dari = "1.4.5"
 agp = "9.0.0"
 coreKtx = "1.13.1"
 junit = "4.13.2"


### PR DESCRIPTION
## Summary

Republish with clean build to ensure Kotlin 2.0.21 compiled artifacts are uploaded to Maven Central.

1.4.4 was published without `./gradlew clean`, causing cached Kotlin 2.2.10 release artifacts to be uploaded instead of freshly compiled Kotlin 2.0.21 ones.

Closes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `dari` dependency to version 1.4.5.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/easyhooon/dari/pull/56)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->