### PR TITLE
docs: add clean build requirement before Maven Central publish

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -7,7 +7,7 @@ Follow these steps:
 - If a version argument was provided and it doesn't match, update all three build.gradle.kts files to the specified version.
 
 ## Step 2: Publish to Maven Central
-- Run `./gradlew publishAllPublicationsToMavenCentralRepository`
+- Run `./gradlew clean publishAllPublicationsToMavenCentralRepository`
 - Verify the build succeeds.
 
 ## Step 3: Create GitHub Release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,10 @@
 - Use clear section headers: `## Summary`, `## Problem` / `## Motivation`, `## Proposed Approach` / `## Proposed Behavior`, etc.
 - Include relevant code snippets, color values, or architecture details where helpful.
 
+## Release
+
+- Always run `./gradlew clean` before `publishAllPublicationsToMavenCentralRepository` to ensure freshly compiled artifacts are uploaded (not stale build cache).
+
 ## Skills
 
 - Code review follow-up: use the `/resolve-coderabbit-review` skill to triage and apply CodeRabbit comments on the current PR.


### PR DESCRIPTION
## Summary

Add a `## Release` section to `CLAUDE.md` documenting that `./gradlew clean` must always precede `publishAllPublicationsToMavenCentralRepository`.

Closes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release guidance requiring a clean build before publishing to Maven Central to avoid stale cached artifacts.
  * Updated the release procedure to include running the clean step as part of the publish workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/easyhooon/dari/pull/58)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/easyhooon/dari/pull/58)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->