### PR TITLE
feat: add fireAndForget flag for one-way bridge calls

### DIFF
--- a/.claude/skills/resolve-coderabbit-review/learned-patterns.md
+++ b/.claude/skills/resolve-coderabbit-review/learned-patterns.md
@@ -20,6 +20,8 @@
 | 단일 색상 매핑을 역할별로 분리 (container/onContainer/onSurface) | 1 | #37 | 2026-04-09 |
 | JSONObject 파싱 크래시 방어 (runCatching 래핑) | 1 | #42 | 2026-04-10 |
 | LocalContext 직접 캐스팅 대신 ContextWrapper 언래핑으로 ComponentActivity 탐색 | 1 | #54 | 2026-05-13 |
+| KDoc 내 인라인 FQN → import 추가 후 simple name으로 교체 | 1 | #60 | 2026-05-14 |
+| Boolean 파라미터를 Boolean?으로 변경하여 null=global default, true/false=per-call override 지원 | 1 | #60 | 2026-05-14 |
 
 ## 거절 패턴 (반복적으로 거절한 코멘트 유형)
 

--- a/dari-core/src/main/kotlin/com/easyhooon/dari/DariConfig.kt
+++ b/dari-core/src/main/kotlin/com/easyhooon/dari/DariConfig.kt
@@ -1,5 +1,6 @@
 package com.easyhooon.dari
 
+import com.easyhooon.dari.interceptor.DariInterceptor
 import kotlin.time.Duration
 
 /**
@@ -30,12 +31,12 @@ data class DariConfig(
     val retentionPeriod: Duration? = null,
     /**
      * When `true`, all bridge calls are treated as fire-and-forget by default:
-     * entries are immediately resolved to [com.easyhooon.dari.MessageStatus.SUCCESS]
+     * entries are immediately resolved to [MessageStatus.SUCCESS]
      * without waiting for a response.
      *
      * Can be overridden per call via the `fireAndForget` parameter on
-     * [com.easyhooon.dari.interceptor.DariInterceptor.onWebToAppRequest] and
-     * [com.easyhooon.dari.interceptor.DariInterceptor.onAppToWebMessage].
+     * [DariInterceptor.onWebToAppRequest] and
+     * [DariInterceptor.onAppToWebMessage].
      *
      * Default is `false` to preserve the existing request–response pairing behavior.
      */

--- a/dari-core/src/main/kotlin/com/easyhooon/dari/DariConfig.kt
+++ b/dari-core/src/main/kotlin/com/easyhooon/dari/DariConfig.kt
@@ -28,6 +28,18 @@ data class DariConfig(
      * Example: `retentionPeriod = 1.days`
      */
     val retentionPeriod: Duration? = null,
+    /**
+     * When `true`, all bridge calls are treated as fire-and-forget by default:
+     * entries are immediately resolved to [com.easyhooon.dari.MessageStatus.SUCCESS]
+     * without waiting for a response.
+     *
+     * Can be overridden per call via the `fireAndForget` parameter on
+     * [com.easyhooon.dari.interceptor.DariInterceptor.onWebToAppRequest] and
+     * [com.easyhooon.dari.interceptor.DariInterceptor.onAppToWebMessage].
+     *
+     * Default is `false` to preserve the existing request–response pairing behavior.
+     */
+    val fireAndForget: Boolean = false,
 ) {
     init {
         require(maxContentLength > 0) { "maxContentLength must be greater than 0" }

--- a/dari-core/src/main/kotlin/com/easyhooon/dari/interceptor/DariInterceptor.kt
+++ b/dari-core/src/main/kotlin/com/easyhooon/dari/interceptor/DariInterceptor.kt
@@ -9,6 +9,10 @@ interface DariInterceptor {
     val tag: String?
         get() = null
 
+    // fireAndForget is Boolean? (not Boolean) to represent three states:
+    // null = defer to DariConfig.fireAndForget, true = force fire-and-forget, false = force request-response.
+    // A plain Boolean would collapse null into one of the two values, making per-call override impossible.
+
     /** Called when a Web -> App request is received */
     fun onWebToAppRequest(handlerName: String, requestId: String?, requestData: String?, fireAndForget: Boolean? = null)
 

--- a/dari-core/src/main/kotlin/com/easyhooon/dari/interceptor/DariInterceptor.kt
+++ b/dari-core/src/main/kotlin/com/easyhooon/dari/interceptor/DariInterceptor.kt
@@ -10,13 +10,13 @@ interface DariInterceptor {
         get() = null
 
     /** Called when a Web -> App request is received */
-    fun onWebToAppRequest(handlerName: String, requestId: String?, requestData: String?)
+    fun onWebToAppRequest(handlerName: String, requestId: String?, requestData: String?, fireAndForget: Boolean = false)
 
     /** Called when a response is sent for a Web -> App request */
     fun onWebToAppResponse(handlerName: String, requestId: String?, responseData: String?, isSuccess: Boolean)
 
     /** Called when an App -> Web message is sent */
-    fun onAppToWebMessage(handlerName: String, requestId: String?, data: String?)
+    fun onAppToWebMessage(handlerName: String, requestId: String?, data: String?, fireAndForget: Boolean = false)
 
     /** Called when a web response is received for an App -> Web request */
     fun onAppToWebResponse(requestId: String?, isSuccess: Boolean, responseData: String?)

--- a/dari-core/src/main/kotlin/com/easyhooon/dari/interceptor/DariInterceptor.kt
+++ b/dari-core/src/main/kotlin/com/easyhooon/dari/interceptor/DariInterceptor.kt
@@ -10,13 +10,13 @@ interface DariInterceptor {
         get() = null
 
     /** Called when a Web -> App request is received */
-    fun onWebToAppRequest(handlerName: String, requestId: String?, requestData: String?, fireAndForget: Boolean = false)
+    fun onWebToAppRequest(handlerName: String, requestId: String?, requestData: String?, fireAndForget: Boolean? = null)
 
     /** Called when a response is sent for a Web -> App request */
     fun onWebToAppResponse(handlerName: String, requestId: String?, responseData: String?, isSuccess: Boolean)
 
     /** Called when an App -> Web message is sent */
-    fun onAppToWebMessage(handlerName: String, requestId: String?, data: String?, fireAndForget: Boolean = false)
+    fun onAppToWebMessage(handlerName: String, requestId: String?, data: String?, fireAndForget: Boolean? = null)
 
     /** Called when a web response is received for an App -> Web request */
     fun onAppToWebResponse(requestId: String?, isSuccess: Boolean, responseData: String?)

--- a/dari/src/main/kotlin/com/easyhooon/dari/interceptor/DefaultDariInterceptor.kt
+++ b/dari/src/main/kotlin/com/easyhooon/dari/interceptor/DefaultDariInterceptor.kt
@@ -19,9 +19,9 @@ class DefaultDariInterceptor(
     private val maxContentLength: Int
         get() = Dari.config.maxContentLength
 
-    override fun onWebToAppRequest(handlerName: String, requestId: String?, requestData: String?, fireAndForget: Boolean) {
+    override fun onWebToAppRequest(handlerName: String, requestId: String?, requestData: String?, fireAndForget: Boolean?) {
         val (truncatedData, wasTruncated) = MessageEntry.truncateIfNeeded(requestData, maxContentLength)
-        val resolvedAsSuccess = fireAndForget || Dari.config.fireAndForget
+        val resolvedAsSuccess = fireAndForget ?: Dari.config.fireAndForget
         val entry = MessageEntry(
             requestId = requestId,
             handlerName = handlerName,
@@ -55,9 +55,9 @@ class DefaultDariInterceptor(
         }
     }
 
-    override fun onAppToWebMessage(handlerName: String, requestId: String?, data: String?, fireAndForget: Boolean) {
+    override fun onAppToWebMessage(handlerName: String, requestId: String?, data: String?, fireAndForget: Boolean?) {
         val (truncatedData, wasTruncated) = MessageEntry.truncateIfNeeded(data, maxContentLength)
-        val resolvedAsSuccess = fireAndForget || Dari.config.fireAndForget
+        val resolvedAsSuccess = fireAndForget ?: Dari.config.fireAndForget
         val entry = MessageEntry(
             requestId = requestId,
             handlerName = handlerName,

--- a/dari/src/main/kotlin/com/easyhooon/dari/interceptor/DefaultDariInterceptor.kt
+++ b/dari/src/main/kotlin/com/easyhooon/dari/interceptor/DefaultDariInterceptor.kt
@@ -19,8 +19,9 @@ class DefaultDariInterceptor(
     private val maxContentLength: Int
         get() = Dari.config.maxContentLength
 
-    override fun onWebToAppRequest(handlerName: String, requestId: String?, requestData: String?) {
+    override fun onWebToAppRequest(handlerName: String, requestId: String?, requestData: String?, fireAndForget: Boolean) {
         val (truncatedData, wasTruncated) = MessageEntry.truncateIfNeeded(requestData, maxContentLength)
+        val resolvedAsSuccess = fireAndForget || Dari.config.fireAndForget
         val entry = MessageEntry(
             requestId = requestId,
             handlerName = handlerName,
@@ -28,6 +29,7 @@ class DefaultDariInterceptor(
             tag = tag,
             requestData = truncatedData,
             requestDataTruncated = wasTruncated,
+            status = if (resolvedAsSuccess) MessageStatus.SUCCESS else MessageStatus.IN_PROGRESS,
         )
         Dari.repository.addEntry(entry)
         Dari.postMessageNotification(handlerName, MessageDirection.WEB_TO_APP, tag)
@@ -53,8 +55,9 @@ class DefaultDariInterceptor(
         }
     }
 
-    override fun onAppToWebMessage(handlerName: String, requestId: String?, data: String?) {
+    override fun onAppToWebMessage(handlerName: String, requestId: String?, data: String?, fireAndForget: Boolean) {
         val (truncatedData, wasTruncated) = MessageEntry.truncateIfNeeded(data, maxContentLength)
+        val resolvedAsSuccess = fireAndForget || Dari.config.fireAndForget
         val entry = MessageEntry(
             requestId = requestId,
             handlerName = handlerName,
@@ -62,6 +65,7 @@ class DefaultDariInterceptor(
             tag = tag,
             requestData = truncatedData,
             requestDataTruncated = wasTruncated,
+            status = if (resolvedAsSuccess) MessageStatus.SUCCESS else MessageStatus.IN_PROGRESS,
         )
         Dari.repository.addEntry(entry)
         Dari.postMessageNotification(handlerName, MessageDirection.APP_TO_WEB, tag)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-dari = "1.4.5"
+dari = "1.4.6"
 agp = "9.0.0"
 coreKtx = "1.13.1"
 junit = "4.13.2"

--- a/sample/src/main/assets/sample.html
+++ b/sample/src/main/assets/sample.html
@@ -124,6 +124,16 @@
         <span>Screen tracking without response (requestId = null)</span>
     </button>
 
+    <div class="section">fireAndForget Flag Test</div>
+    <button class="btn btn-green" onclick="fireAndForgetPerCall()">
+        Per-call fireAndForget=true
+        <span>Has requestId, but auto-resolves to SUCCESS immediately</span>
+    </button>
+    <button class="btn btn-orange" onclick="noResponsePending()">
+        No Response (stays IN_PROGRESS)
+        <span>No flag + no response = forever IN_PROGRESS (contrast)</span>
+    </button>
+
     <div id="log"></div>
 
     <script>
@@ -220,6 +230,19 @@
             var data = JSON.stringify({ errorType: "network_timeout" });
             log('→ simulateError', 'req');
             Android.onBridgeRequest('simulateError', id, data);
+        }
+
+        function fireAndForgetPerCall() {
+            var id = createRequestId();
+            var data = JSON.stringify({ action: "track_conversion", value: 42 });
+            log('→ fireAndForgetPerCall (flag=true)', 'req');
+            Android.onBridgeRequest('fireAndForgetPerCall', id, data);
+        }
+
+        function noResponsePending() {
+            var id = createRequestId();
+            log('→ noResponsePending (IN_PROGRESS forever)', 'req');
+            Android.onBridgeRequest('noResponsePending', id, null);
         }
 
         function logEvent() {

--- a/sample/src/main/java/com/easyhooon/dari/sample/MainActivity.kt
+++ b/sample/src/main/java/com/easyhooon/dari/sample/MainActivity.kt
@@ -89,7 +89,8 @@ class MainActivity : ComponentActivity() {
         @RequiresApi(Build.VERSION_CODES.P)
         @JavascriptInterface
         fun onBridgeRequest(handlerName: String, requestId: String, data: String?) {
-            interceptor?.onWebToAppRequest(handlerName, requestId, data)
+            val perCallFireAndForget = if (handlerName == "fireAndForgetPerCall") true else null
+            interceptor?.onWebToAppRequest(handlerName, requestId, data, fireAndForget = perCallFireAndForget)
 
             when (handlerName) {
                 "getAppInfo" -> handleGetAppInfo(requestId)
@@ -103,6 +104,8 @@ class MainActivity : ComponentActivity() {
                 "fetchLargeData" -> handleFetchLargeData(handlerName, requestId)
                 "simulateSlowResponse" -> handleSimulateSlowResponse(handlerName, requestId)
                 "simulateError" -> handleSimulateError(handlerName, requestId, data)
+                "fireAndForgetPerCall" -> { /* auto-resolved to SUCCESS by Dari via fireAndForget=true */ }
+                "noResponsePending" -> { /* intentionally no response — stays IN_PROGRESS */ }
                 else -> {
                     val error = """{"error":"Unknown handler","handler":"$handlerName"}"""
                     interceptor?.onWebToAppResponse(handlerName, requestId, error, false)


### PR DESCRIPTION
## Summary

- Adds `fireAndForget: Boolean = false` to `DariConfig` as a global default
- Adds `fireAndForget: Boolean = false` per-call parameter to `DariInterceptor.onWebToAppRequest` and `onAppToWebMessage`
- When the flag is active (global or per-call), entries are created with `SUCCESS` immediately — the `IN_PROGRESS` state is never shown for those calls

## Motivation

One-way bridge handlers that never send a response were permanently stuck in `IN_PROGRESS`, making it impossible to distinguish intentional fire-and-forget calls from genuinely hung requests.

## Test Plan

- [x] Global `DariConfig(fireAndForget = true)` — all calls appear green immediately
- [x] Per-call `fireAndForget = true` — only that call resolves immediately; others behave normally
- [x] Default (`fireAndForget = false`) — existing request–response pairing is unchanged

Closes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional fire-and-forget mode for bridge messages (disabled by default); when used globally or per-call, requests resolve immediately with SUCCESS without waiting for a response, reducing latency for one-way interactions.

* **Documentation**
  * Updated interceptor API docs and README to reflect the renamed request callback and new fire-and-forget behavior.

* **Samples**
  * Added sample UI controls demonstrating per-call fire-and-forget and a no-response-pending scenario.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/easyhooon/dari/pull/60)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->