### PR TITLE
chore: upgrade to Node.js 24, add docs link to README

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,8 @@
 name: Documentation
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches: [main]
@@ -36,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: documentation/package-lock.json
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 Just as Chucker intercepts and displays HTTP traffic, Dari captures and visualizes **WebView JavaScript bridge messages** between your web content and native Android code.
 
+📖 **[Documentation](https://easyhooon.github.io/dari)** — Setup guide, configuration reference, and API docs.
+
 ## Screenshots
 
 <table>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Dari
 
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.easyhooon/dari)](https://central.sonatype.com/artifact/io.github.easyhooon/dari)
+[![Documentation](https://img.shields.io/badge/docs-easyhooon.github.io%2Fdari-blue)](https://easyhooon.github.io/dari)
 
 **Dari** (다리) means **"bridge"** in Korean. Dari is an Android library for inspecting WebView bridge communication in real time, inspired by [Chucker](https://github.com/ChuckerTeam/chucker).
 


### PR DESCRIPTION
## Summary

- Upgrades `setup-node` to Node.js 24 and sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to suppress GitHub Actions Node.js 20 deprecation warnings
- Adds documentation site badge and inline link to README