### PR TITLE
docs: replace placeholder logo with dari bridge logo on landing page

### DIFF
--- a/documentation/app/page.tsx
+++ b/documentation/app/page.tsx
@@ -1,22 +1,10 @@
 import Link from 'next/link';
 
-function DariLogo() {
-  return (
-    <div className="rounded-2xl bg-gray-100 p-5 dark:bg-neutral-800">
-      <svg width="48" height="48" viewBox="0 0 960 960" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path
-          d="M280,800 L80,600l200,-200 56,57 -103,103h287v80L233,640l103,103 -56,57ZM680,560 L624,503 727,400L440,400v-80h287L624,217l56,-57 200,200 -200,200Z"
-          className="fill-gray-800 dark:fill-gray-200"
-        />
-      </svg>
-    </div>
-  );
-}
-
 export default function HomePage() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-8 bg-white px-4 text-center dark:bg-neutral-950">
-      <DariLogo />
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src="/dari/logo.png" alt="Dari logo" width={280} height={280} className="rounded-3xl" />
       <h1 className="text-7xl font-bold tracking-tight">Dari</h1>
       <p className="max-w-xl text-xl text-gray-500 dark:text-gray-400">
         A Chucker-inspired WebView bridge communication inspector for Android.


### PR DESCRIPTION
## Summary

- Replace the generic arrow SVG placeholder in `DariLogo` with the actual dari bridge logo image (`public/logo.png`)
- Logo displayed at 280×280 with rounded corners on the landing page