### PR TITLE
docs: restore og:url to openGraph metadata

### DIFF
--- a/documentation/app/layout.tsx
+++ b/documentation/app/layout.tsx
@@ -11,6 +11,7 @@ export const metadata: Metadata = {
   title: 'Dari - WebView Bridge Inspector for Android',
   description: 'A Chucker-inspired debug inspector for WebView bridge communication on Android.',
   openGraph: {
+    url: 'https://easyhooon.github.io/dari',
     siteName: 'Dari',
     images: [{ url: '/opengraph-image', width: 1200, height: 630, alt: 'Dari - WebView Bridge Inspector for Android' }],
     type: 'website',


### PR DESCRIPTION
## Summary

Restores `og:url` to the `openGraph` metadata block in `layout.tsx`.

Previously removed as a CodeRabbit nitpick, but `og:url` is required by some social platforms to correctly identify the canonical page URL when rendering link previews.