### PR TITLE
docs: fix OG image content-type for GitHub Pages

### DIFF
--- a/documentation/app/layout.tsx
+++ b/documentation/app/layout.tsx
@@ -13,12 +13,12 @@ export const metadata: Metadata = {
   openGraph: {
     url: 'https://easyhooon.github.io/dari',
     siteName: 'Dari',
-    images: [{ url: '/opengraph-image', width: 1200, height: 630, alt: 'Dari - WebView Bridge Inspector for Android' }],
+    images: [{ url: '/og.png', width: 1200, height: 630, alt: 'Dari - WebView Bridge Inspector for Android' }],
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    images: ['/opengraph-image'],
+    images: ['/og.png'],
   },
 };
 

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build": "next build && cp out/opengraph-image out/og.png",
     "start": "next start"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

GitHub Pages serves extensionless files as `application/octet-stream`, which social platforms (Slack, KakaoTalk, Twitter/X) reject as an OG image.

- Add postbuild step in `package.json` to copy `out/opengraph-image` → `out/og.png`
- Update `og:image` and `twitter:image` URLs to `/og.png` so GitHub Pages serves the file with the correct `image/png` content-type