### PR TITLE
docs: bump og:image URL to force KakaoTalk cache refresh

### DIFF
--- a/documentation/app/layout.tsx
+++ b/documentation/app/layout.tsx
@@ -13,12 +13,12 @@ export const metadata: Metadata = {
   openGraph: {
     url: 'https://easyhooon.github.io/dari',
     siteName: 'Dari',
-    images: [{ url: '/dari/og.png', width: 1200, height: 630, alt: 'Dari - WebView Bridge Inspector for Android' }],
+    images: [{ url: '/dari/og.png?v=2', width: 1200, height: 630, alt: 'Dari - WebView Bridge Inspector for Android' }],
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    images: ['/dari/og.png'],
+    images: ['/dari/og.png?v=2'],
   },
 };
 


### PR DESCRIPTION
## Summary

KakaoTalk aggressively caches OG images by URL. Adding `?v=2` to the `og:image` URL forces KakaoTalk to treat it as a new URL and re-scrape the image.

GitHub Pages ignores query parameters for static files, so `og.png?v=2` still serves the same file with `image/png` content-type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated social media preview image URLs with versioned asset paths to ensure proper caching and display across platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/easyhooon/dari/pull/72)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->