### PR TITLE
fix: align noop Dari API surface

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,5 +4,5 @@ Dari adopts the JetBrains Open Source and Community Code of Conduct:
 
 https://github.com/JetBrains#code-of-conduct
 
-Please report unacceptable behavior by opening a GitHub issue or by contacting
+Please report unacceptable behavior by contacting
 the project maintainer privately at mraz3068@gmail.com.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+Dari adopts the JetBrains Open Source and Community Code of Conduct:
+
+https://github.com/JetBrains#code-of-conduct
+
+Please report unacceptable behavior by opening a GitHub issue or by contacting
+the project maintainer privately at mraz3068@gmail.com.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 easyhooon
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ class MyApp : Application() {
                 maxContentLength = 500_000,     // Default: 500,000 (truncate large payloads)
                 shakeToOpen = true,             // Default: false
                 retentionPeriod = 1.days,       // Default: null (disabled)
+                fireAndForget = false,          // Default: false
             )
         )
     }
@@ -162,6 +163,7 @@ class MyApp : Application() {
 | `maxContentLength` | `Int` | `500,000` | Truncate request/response payloads exceeding this length |
 | `shakeToOpen` | `Boolean` | `false` | Enable shake gesture to open Dari UI |
 | `retentionPeriod` | `Duration?` | `null` | TTL-based message cleanup (e.g., `1.hours`, `3.days`). `null` disables it |
+| `fireAndForget` | `Boolean` | `false` | Treat bridge calls as one-way by default without waiting for responses |
 
 ## Module Structure
 
@@ -180,6 +182,13 @@ The `sample/` module contains a working WebView demo with realistic bridge scena
 1. A notification appears showing recent bridge messages
 2. Tap the notification to open the message list
 3. Tap any message to see its details (overview, request payload, response payload)
+
+## Security & Privacy
+
+Dari is intended for debug and internal builds. Bridge payloads may contain
+tokens, personal data, or other sensitive values, so avoid sharing exported
+messages without reviewing them first. Use `dari-noop` in release builds to
+keep the same API surface without storing or displaying bridge messages.
 
 ## API Reference
 
@@ -209,11 +218,16 @@ The `sample/` module contains a working WebView demo with realistic bridge scena
  * Injected into WebViewBridge to capture all bridge messages.
  */
 interface DariInterceptor {
+    /** Tag identifying the source of messages captured by this interceptor */
+    val tag: String?
+        get() = null
+
     /** Called when a Web -> App request is received */
     fun onWebToAppRequest(
         handlerName: String,
         requestId: String?,
         requestData: String?,
+        fireAndForget: Boolean? = null,
     )
 
     /** Called when a response is sent for a Web -> App request */
@@ -229,6 +243,7 @@ interface DariInterceptor {
         handlerName: String,
         requestId: String?,
         data: String?,
+        fireAndForget: Boolean? = null,
     )
 
     /** Called when a web response is received for an App -> Web request */

--- a/dari-core/src/main/kotlin/com/easyhooon/dari/DariConfig.kt
+++ b/dari-core/src/main/kotlin/com/easyhooon/dari/DariConfig.kt
@@ -36,7 +36,7 @@ data class DariConfig(
      *
      * Can be overridden per call via the `fireAndForget` parameter on
      * [DariInterceptor.onWebToAppRequest] and
-     * [DariInterceptor.onAppToWebMessage].
+     * [DariInterceptor.onAppToWebRequest].
      *
      * Default is `false` to preserve the existing request–response pairing behavior.
      */

--- a/dari-noop/src/main/kotlin/com/easyhooon/dari/Dari.kt
+++ b/dari-noop/src/main/kotlin/com/easyhooon/dari/Dari.kt
@@ -14,5 +14,13 @@ object Dari {
     @Suppress("UNUSED_PARAMETER", "FunctionOnlyReturningConstant")
     fun createInterceptor(tag: String? = null): DariInterceptor? = null
 
+    @Suppress("UNUSED_PARAMETER")
+    fun setShakeToOpenEnabled(enabled: Boolean) = Unit
+
+    @Suppress("UNUSED_PARAMETER")
+    fun setDarkMode(value: Boolean?) = Unit
+
+    fun showNotification() = Unit
+
     fun clear() = Unit
 }

--- a/documentation/content/docs/configuration.mdx
+++ b/documentation/content/docs/configuration.mdx
@@ -3,12 +3,12 @@ title: Configuration
 description: DariConfig options reference
 ---
 
-Pass a `DariConfig` instance to `Dari.initialize()` to customize behavior.
+Pass a `DariConfig` instance to `Dari.init()` to customize behavior before or during app startup.
 
 ```kotlin
 // import kotlin.time.Duration.Companion.days
 // import kotlin.time.Duration.Companion.hours
-Dari.initialize(
+Dari.init(
     context = this,
     config = DariConfig(
         maxEntries = 500,
@@ -46,7 +46,7 @@ Opens the Dari inspector screen when the device is shaken.
 ### `retentionPeriod`
 **Type**: `Duration?` | **Default**: `null`
 
-TTL-based cleanup — messages older than this duration are deleted automatically.
+TTL-based cleanup deletes messages older than this duration automatically.
 
 ```kotlin
 // import kotlin.time.Duration.Companion.hours

--- a/documentation/content/docs/index.mdx
+++ b/documentation/content/docs/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: Introduction
-description: Dari — WebView bridge communication inspector for Android
+description: Dari, WebView bridge communication inspector for Android
 ---
 
 ## What is Dari?
 
-Dari is a debug inspector library for Android WebView bridge communication, inspired by [Chucker](https://github.com/ChuckerTeam/chucker). It captures and displays all WebView↔App bridge messages in a persistent notification and an in-app UI — without any changes to your existing bridge logic.
+Dari is a debug inspector library for Android WebView bridge communication, inspired by [Chucker](https://github.com/ChuckerTeam/chucker). It captures and displays all WebView↔App bridge messages in a persistent notification and an in-app UI without changing your existing bridge logic.
 
 ## Features
 
@@ -15,12 +15,13 @@ Dari is a debug inspector library for Android WebView bridge communication, insp
 - **Shake-to-open** gesture to launch the inspector
 - **Status filter** to focus on errors or in-progress calls
 - **Export** captured messages as JSON
-- **No-op module** (`dari-noop`) for release builds — zero overhead in production
+- **No-op module** (`dari-noop`) for release builds with no runtime overhead
 - **Fire-and-forget** support for one-way bridge calls
+- **Same public API surface** across debug and release artifacts
 
 ## How It Works
 
-Dari wraps your existing bridge callbacks with a `DariInterceptor`. Each call is stored as a `MessageEntry` with request/response data, timestamps, and status. The inspector UI shows all entries in real time.
+Create a `DariInterceptor` with `Dari.createInterceptor()` and call it from your existing bridge callbacks. Each debug call is stored as a `MessageEntry` with request/response data, timestamps, and status. The inspector UI shows all entries in real time.
 
 ## Modules
 

--- a/documentation/content/docs/interceptor.mdx
+++ b/documentation/content/docs/interceptor.mdx
@@ -40,13 +40,13 @@ interface DariInterceptor {
 
 ## DefaultDariInterceptor
 
-The built-in implementation. Stores messages in Dari's Room database and posts notifications.
+`DefaultDariInterceptor` is the debug implementation. It stores messages in Dari's Room database and posts notifications.
 
 ```kotlin
-val interceptor = DefaultDariInterceptor(tag = "PaymentBridge")
+val interceptor = Dari.createInterceptor(tag = "PaymentBridge")
 ```
 
-The optional `tag` labels messages by bridge source when multiple interceptors are active in the same app.
+Use `Dari.createInterceptor()` in app code so release builds compile against `dari-noop`. The optional `tag` labels messages by bridge source when multiple interceptors are active in the same app.
 
 ## Methods
 
@@ -86,13 +86,13 @@ One-way calls that never receive a response can be marked so they immediately re
 
 ```kotlin
 // Per-call
-interceptor.onWebToAppRequest(
+interceptor?.onWebToAppRequest(
     handlerName = "logEvent",
     requestId = null,
     requestData = """{"event": "button_click"}""",
     fireAndForget = true,
 )
 
-// Global — all calls
+// Global setting: all calls
 DariConfig(fireAndForget = true)
 ```

--- a/documentation/content/docs/ko/configuration.mdx
+++ b/documentation/content/docs/ko/configuration.mdx
@@ -3,10 +3,10 @@ title: 설정 옵션
 description: DariConfig 옵션 레퍼런스
 ---
 
-`Dari.initialize()`에 `DariConfig` 인스턴스를 전달하여 동작을 커스터마이징합니다.
+`Dari.init()`에 `DariConfig` 인스턴스를 전달하여 앱 시작 전후의 동작을 커스터마이징합니다.
 
 ```kotlin
-Dari.initialize(
+Dari.init(
     context = this,
     config = DariConfig(
         maxEntries = 500,

--- a/documentation/content/docs/ko/index.mdx
+++ b/documentation/content/docs/ko/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: 소개
-description: Dari — Android WebView 브릿지 통신 인스펙터
+description: Dari, Android WebView 브릿지 통신 인스펙터
 ---
 
 ## Dari란?
@@ -15,12 +15,13 @@ Dari는 [Chucker](https://github.com/ChuckerTeam/chucker)에서 영감을 받아
 - **흔들기로 열기**: 디바이스를 흔들어 인스펙터 실행
 - **상태 필터**: 오류 또는 진행 중인 호출만 필터링
 - **JSON 내보내기**: 캡처된 메시지를 JSON으로 내보내기
-- **No-op 모듈** (`dari-noop`): 릴리즈 빌드에서 완전히 제거
+- **No-op 모듈** (`dari-noop`): 릴리즈 빌드에서 런타임 오버헤드 제거
 - **단방향(Fire-and-Forget) 지원**: 응답이 없는 브릿지 호출 처리
+- **동일한 공개 API**: 디버그와 릴리즈 아티팩트의 API 표면 일치
 
 ## 동작 방식
 
-`DariInterceptor`를 기존 브릿지 콜백에 연결하면, 각 호출이 요청/응답 데이터, 타임스탬프, 상태를 포함한 `MessageEntry`로 저장됩니다. 인스펙터 UI에서 모든 항목을 실시간으로 확인할 수 있습니다.
+`Dari.createInterceptor()`로 `DariInterceptor`를 생성하고 기존 브릿지 콜백에서 호출합니다. 디버그 빌드의 각 호출은 요청/응답 데이터, 타임스탬프, 상태를 포함한 `MessageEntry`로 저장됩니다. 인스펙터 UI에서 모든 항목을 실시간으로 확인할 수 있습니다.
 
 ## 모듈 구성
 

--- a/documentation/content/docs/ko/interceptor.mdx
+++ b/documentation/content/docs/ko/interceptor.mdx
@@ -40,13 +40,13 @@ interface DariInterceptor {
 
 ## DefaultDariInterceptor
 
-기본 구현체입니다. 메시지를 Dari의 Room 데이터베이스에 저장하고 알림을 표시합니다.
+`DefaultDariInterceptor`는 디버그 구현체입니다. 메시지를 Dari의 Room 데이터베이스에 저장하고 알림을 표시합니다.
 
 ```kotlin
-val interceptor = DefaultDariInterceptor(tag = "PaymentBridge")
+val interceptor = Dari.createInterceptor(tag = "PaymentBridge")
 ```
 
-선택적 `tag`를 사용하면 앱에 여러 인터셉터가 활성화된 경우 브릿지 소스별로 메시지를 구분할 수 있습니다.
+앱 코드에서는 `Dari.createInterceptor()`를 사용해야 릴리즈 빌드가 `dari-noop`과 함께 컴파일됩니다. 선택적 `tag`를 사용하면 앱에 여러 인터셉터가 활성화된 경우 브릿지 소스별로 메시지를 구분할 수 있습니다.
 
 ## 메서드
 
@@ -86,13 +86,13 @@ JavaScript가 네이티브 앱의 요청에 응답할 때 호출합니다.
 
 ```kotlin
 // 개별 호출
-interceptor.onWebToAppRequest(
+interceptor?.onWebToAppRequest(
     handlerName = "logEvent",
     requestId = null,
     requestData = """{"event": "button_click"}""",
     fireAndForget = true,
 )
 
-// 전역 설정 — 모든 호출에 적용
+// 전역 설정: 모든 호출에 적용
 DariConfig(fireAndForget = true)
 ```

--- a/documentation/content/docs/ko/modules.mdx
+++ b/documentation/content/docs/ko/modules.mdx
@@ -3,26 +3,26 @@ title: 모듈 구조
 description: 프로덕션 오버헤드 제로를 위한 세 모듈 아키텍처
 ---
 
-Dari는 릴리즈 빌드에서 디버그 코드를 완전히 제거하기 위해 세 모듈로 분리되어 있습니다.
+Dari는 릴리즈 빌드에 디버그 구현이 포함되지 않도록 세 모듈로 분리되어 있습니다.
 
 ## `dari-core`
 
 UI, Room DB, 알림이 없는 순수 Kotlin/Android 모듈입니다.
 
 포함 내용:
-- `DariConfig` — 설정 데이터 클래스
-- `DariInterceptor` — 브릿지 메시지 캡처 인터페이스
-- `MessageEntry` — 브릿지 호출 라이프사이클 데이터 모델
-- `MessageStatus` — 열거형: `IN_PROGRESS`, `SUCCESS`, `ERROR`
-- `MessageDirection` — 열거형: `WEB_TO_APP`, `APP_TO_WEB`
+- `DariConfig`: 설정 데이터 클래스
+- `DariInterceptor`: 브릿지 메시지 캡처 인터페이스
+- `MessageEntry`: 브릿지 호출 라이프사이클 데이터 모델
+- `MessageStatus`: 열거형: `IN_PROGRESS`, `SUCCESS`, `ERROR`
+- `MessageDirection`: 열거형: `WEB_TO_APP`, `APP_TO_WEB`
 
 ## `dari`
 
 `dari-core`에 의존하는 전체 디버그 구현체입니다.
 
 포함 내용:
-- `DefaultDariInterceptor` — Room에 메시지 저장, 알림 표시
-- `Dari` — 싱글톤 진입점 (`initialize`, `repository`, `config`)
+- `DefaultDariInterceptor`: Room에 메시지 저장, 알림 표시
+- `Dari`: 싱글톤 진입점 (`init`, `createInterceptor`, `clear`)
 - 인스펙터 UI (Jetpack Compose)
 - Room 데이터베이스 + DAO
 - 흔들기 감지 센서
@@ -31,6 +31,6 @@ UI, Room DB, 알림이 없는 순수 Kotlin/Android 모듈입니다.
 
 ## `dari-noop`
 
-`dari-core`에 의존하는 No-op 스텁입니다. 모든 공개 API가 빈 구현이며 — `Dari.initialize()`는 아무것도 하지 않고, `DefaultDariInterceptor` 메서드도 아무것도 기록하지 않습니다.
+`dari-core`에 의존하는 No-op 스텁입니다. `Dari.init()`과 다른 런타임 API는 아무것도 하지 않고, `Dari.createInterceptor()`는 `null`을 반환합니다.
 
 프로덕션 빌드에서 런타임 오버헤드가 전혀 없도록 `releaseImplementation`에 추가하세요.

--- a/documentation/content/docs/ko/setup.mdx
+++ b/documentation/content/docs/ko/setup.mdx
@@ -9,8 +9,8 @@ description: Android 프로젝트에 Dari 추가하기
 
 ```kotlin
 dependencies {
-    debugImplementation("io.github.easyhooon:dari:1.4.5")
-    releaseImplementation("io.github.easyhooon:dari-noop:1.4.5")
+    debugImplementation("io.github.easyhooon:dari:1.5.0")
+    releaseImplementation("io.github.easyhooon:dari-noop:1.5.0")
 }
 ```
 
@@ -18,45 +18,45 @@ dependencies {
 
 ## 초기화
 
-`Application` 클래스에서 `Dari.initialize()`를 호출합니다:
+Dari는 AndroidX Startup으로 자동 초기화됩니다. 설정을 바꾸고 싶을 때만 `Application` 클래스에서 `Dari.init()`을 호출합니다:
 
 ```kotlin
 class MyApp : Application() {
     override fun onCreate() {
         super.onCreate()
-        Dari.initialize(this)
+        Dari.init(
+            context = this,
+            config = DariConfig(
+                showNotification = true,
+                shakeToOpen = true,
+            )
+        )
     }
 }
 ```
 
-`DariConfig`를 전달하여 동작을 커스터마이징할 수 있습니다:
-
-```kotlin
-Dari.initialize(
-    context = this,
-    config = DariConfig(
-        showNotification = true,
-        shakeToOpen = true,
-    )
-)
-```
+기본 설정을 사용할 때는 초기화 코드를 작성하지 않아도 됩니다.
 
 ## 브릿지 연결
 
-`DefaultDariInterceptor`를 생성하고 각 브릿지 지점에서 메서드를 호출합니다:
+디버그와 릴리즈 빌드에서 같은 코드가 컴파일되도록 `Dari.createInterceptor()`로 인터셉터를 생성합니다:
 
 ```kotlin
-val interceptor = DefaultDariInterceptor(tag = "MyBridge")
+val interceptor = Dari.createInterceptor(tag = "MyBridge")
+```
 
+각 브릿지 지점에서 인터셉터 메서드를 호출합니다. 릴리즈 빌드에서는 `dari-noop`이 `null`을 반환하므로 safe call을 사용합니다:
+
+```kotlin
 // Web → App: 요청 수신
-interceptor.onWebToAppRequest(
+interceptor?.onWebToAppRequest(
     handlerName = "getUserInfo",
     requestId = "req_001",
     requestData = """{"userId": 123}""",
 )
 
 // Web → App: 응답 전송
-interceptor.onWebToAppResponse(
+interceptor?.onWebToAppResponse(
     handlerName = "getUserInfo",
     requestId = "req_001",
     responseData = """{"name": "John"}""",

--- a/documentation/content/docs/modules.mdx
+++ b/documentation/content/docs/modules.mdx
@@ -10,19 +10,19 @@ Dari is split into three modules to keep release builds free of debug code.
 Pure Kotlin/Android module with no UI, no Room database, and no notifications.
 
 Contains:
-- `DariConfig` — configuration data class
-- `DariInterceptor` — interface for capturing bridge messages
-- `MessageEntry` — data model for a bridge call lifecycle
-- `MessageStatus` — enum: `IN_PROGRESS`, `SUCCESS`, `ERROR`
-- `MessageDirection` — enum: `WEB_TO_APP`, `APP_TO_WEB`
+- `DariConfig`: configuration data class
+- `DariInterceptor`: interface for capturing bridge messages
+- `MessageEntry`: data model for a bridge call lifecycle
+- `MessageStatus`: enum: `IN_PROGRESS`, `SUCCESS`, `ERROR`
+- `MessageDirection`: enum: `WEB_TO_APP`, `APP_TO_WEB`
 
 ## `dari`
 
 Full debug implementation. Depends on `dari-core`.
 
 Contains:
-- `DefaultDariInterceptor` — stores messages in Room, posts notifications
-- `Dari` — singleton entry point (`initialize`, `repository`, `config`)
+- `DefaultDariInterceptor`: stores messages in Room, posts notifications
+- `Dari`: singleton entry point (`init`, `createInterceptor`, `clear`)
 - Inspector UI (Jetpack Compose)
 - Room database + DAO
 - Shake-to-open sensor
@@ -31,6 +31,6 @@ Add to `debugImplementation` only.
 
 ## `dari-noop`
 
-No-op stub that depends on `dari-core`. All public APIs are empty — `Dari.initialize()` does nothing, `DefaultDariInterceptor` methods record nothing.
+No-op stub that depends on `dari-core`. `Dari.init()` and other runtime APIs do nothing, while `Dari.createInterceptor()` returns `null`.
 
 Add to `releaseImplementation` to ensure zero runtime overhead in production builds.

--- a/documentation/content/docs/setup.mdx
+++ b/documentation/content/docs/setup.mdx
@@ -9,54 +9,54 @@ Add the dependencies to your app module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    debugImplementation("io.github.easyhooon:dari:1.4.5")
-    releaseImplementation("io.github.easyhooon:dari-noop:1.4.5")
+    debugImplementation("io.github.easyhooon:dari:1.5.0")
+    releaseImplementation("io.github.easyhooon:dari-noop:1.5.0")
 }
 ```
 
-The `dari-noop` module provides empty implementations of all public APIs so your code compiles in release with zero runtime overhead.
+The `dari-noop` module implements the same public APIs with no-op behavior, so your code compiles in release with no runtime overhead.
 
 ## Initialize
 
-Call `Dari.initialize()` in your `Application` class:
+Dari starts automatically through AndroidX Startup. Call `Dari.init()` only when you need custom configuration:
 
 ```kotlin
 class MyApp : Application() {
     override fun onCreate() {
         super.onCreate()
-        Dari.initialize(this)
+        Dari.init(
+            context = this,
+            config = DariConfig(
+                showNotification = true,
+                shakeToOpen = true,
+            )
+        )
     }
 }
 ```
 
-You can pass a `DariConfig` to customize behavior:
-
-```kotlin
-Dari.initialize(
-    context = this,
-    config = DariConfig(
-        showNotification = true,
-        shakeToOpen = true,
-    )
-)
-```
+If you use the default configuration, you do not need any initialization code.
 
 ## Connect Your Bridge
 
-Instantiate a `DefaultDariInterceptor` and call its methods at each bridge point:
+Create an interceptor through `Dari.createInterceptor()` so the same app code compiles in debug and release builds:
 
 ```kotlin
-val interceptor = DefaultDariInterceptor(tag = "MyBridge")
+val interceptor = Dari.createInterceptor(tag = "MyBridge")
+```
 
+Call the interceptor at each bridge point. In release builds, `dari-noop` returns `null`, so use safe calls:
+
+```kotlin
 // Web → App: request received
-interceptor.onWebToAppRequest(
+interceptor?.onWebToAppRequest(
     handlerName = "getUserInfo",
     requestId = "req_001",
     requestData = """{"userId": 123}""",
 )
 
 // Web → App: response sent back
-interceptor.onWebToAppResponse(
+interceptor?.onWebToAppResponse(
     handlerName = "getUserInfo",
     requestId = "req_001",
     responseData = """{"name": "John"}""",


### PR DESCRIPTION
## Summary
- Add missing no-op Dari APIs so release builds match the debug API surface
- Update README, KDoc, and documentation site pages for the current init/createInterceptor/fireAndForget API
- Add Apache 2.0 LICENSE and Code of Conduct files

## Verification
- ./gradlew :dari-core:compileDebugKotlin :dari-noop:compileDebugKotlin
- npm run build (documentation)
- pre-commit hook: detekt and ktlintCheck