### PR TITLE
fix: prevent duplicate message IDs

### DIFF
--- a/dari/src/androidTest/kotlin/com/easyhooon/dari/data/MessageRepositoryTest.kt
+++ b/dari/src/androidTest/kotlin/com/easyhooon/dari/data/MessageRepositoryTest.kt
@@ -6,10 +6,15 @@ import com.easyhooon.dari.MessageDirection
 import com.easyhooon.dari.MessageEntry
 import com.easyhooon.dari.MessageStatus
 import com.easyhooon.dari.data.local.DariDatabase
+import com.easyhooon.dari.data.local.MessageDao
+import com.easyhooon.dari.data.local.MessageEntity
 import com.easyhooon.dari.data.local.toEntity
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -22,7 +27,7 @@ class MessageRepositoryTest {
     private lateinit var repository: MessageRepository
 
     @Before
-    fun setup() {
+    fun setup() = runBlocking {
         // Uses in-memory database (not persisted to disk) for test isolation.
         // Automatically garbage-collected when the test instance is discarded.
         database = Room.inMemoryDatabaseBuilder(
@@ -30,6 +35,7 @@ class MessageRepositoryTest {
             DariDatabase::class.java,
         ).allowMainThreadQueries().build()
         repository = MessageRepository(database, maxEntries = 3)
+        repository.initialized.await()
     }
 
     @After
@@ -50,11 +56,12 @@ class MessageRepositoryTest {
     }
 
     @Test
-    fun addEntry_incrementsMessageCount() {
+    fun addEntry_incrementsMessageCount() = runBlocking {
         repository.addEntry(createEntry("1"))
         repository.addEntry(createEntry("2"))
 
-        assertEquals(2, repository.messageCount.value)
+        val count = withTimeout(5_000) { repository.messageCount.first { it == 2 } }
+        assertEquals(2, count)
     }
 
     @Test
@@ -69,6 +76,34 @@ class MessageRepositoryTest {
         assertEquals("2", entries[0].requestId)
         assertEquals("3", entries[1].requestId)
         assertEquals("4", entries[2].requestId)
+    }
+
+    @Test
+    fun addEntry_keepsIdsUniqueWhenTimestampsMatch() = runBlocking {
+        val timestamp = 1_721_607_904_839L
+        val dao = ControllableMessageDao(database.messageDao())
+        val controlledRepository = MessageRepository(database, maxEntries = 3, dao = dao)
+        controlledRepository.initialized.await()
+
+        try {
+            controlledRepository.addEntry(createEntry("1").copy(requestTimestamp = timestamp))
+            controlledRepository.addEntry(createEntry("2").copy(requestTimestamp = timestamp))
+            assertEquals(2, controlledRepository.entries.value.map { it.id }.distinct().size)
+
+            dao.insertResults.send(101L)
+            val afterFirstInsert = withTimeout(5_000) {
+                controlledRepository.entries.first { entries -> entries.any { it.id == 101L } }
+            }
+            assertEquals(2, afterFirstInsert.map { it.id }.distinct().size)
+
+            dao.insertResults.send(102L)
+            val afterSecondInsert = withTimeout(5_000) {
+                controlledRepository.entries.first { entries -> entries.all { it.id > 0 } }
+            }
+            assertEquals(2, afterSecondInsert.map { it.id }.distinct().size)
+        } finally {
+            controlledRepository.close()
+        }
     }
 
     @Test
@@ -90,13 +125,15 @@ class MessageRepositoryTest {
     }
 
     @Test
-    fun clear_removesAllEntriesAndResetsCount() {
+    fun clear_removesAllEntriesAndResetsCount() = runBlocking {
         repository.addEntry(createEntry("1"))
         repository.addEntry(createEntry("2"))
+        withTimeout(5_000) { repository.messageCount.first { it == 2 } }
         repository.clear()
 
         assertTrue(repository.entries.value.isEmpty())
-        assertEquals(0, repository.messageCount.value)
+        val count = withTimeout(5_000) { repository.messageCount.first { it == 0 } }
+        assertEquals(0, count)
     }
 
     @Test
@@ -121,4 +158,10 @@ class MessageRepositoryTest {
         handlerName = "testHandler",
         direction = MessageDirection.WEB_TO_APP,
     )
+
+    private class ControllableMessageDao(delegate: MessageDao) : MessageDao by delegate {
+        val insertResults = Channel<Long>()
+
+        override suspend fun insert(entity: MessageEntity): Long = insertResults.receive()
+    }
 }

--- a/dari/src/main/kotlin/com/easyhooon/dari/data/MessageRepository.kt
+++ b/dari/src/main/kotlin/com/easyhooon/dari/data/MessageRepository.kt
@@ -2,9 +2,11 @@ package com.easyhooon.dari.data
 
 import com.easyhooon.dari.MessageEntry
 import com.easyhooon.dari.data.local.DariDatabase
+import com.easyhooon.dari.data.local.MessageDao
 import com.easyhooon.dari.data.local.toEntity
 import com.easyhooon.dari.data.local.toMessageEntry
 import androidx.annotation.VisibleForTesting
+import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -25,7 +27,7 @@ import kotlinx.coroutines.launch
  * while persisting to the database in the background.
  */
 class MessageRepository internal constructor(
-    private val database: DariDatabase,
+    database: DariDatabase,
     private val maxEntries: Int = 500,
     /**
      * Optional TTL in milliseconds. Messages with `requestTimestamp` older than
@@ -34,10 +36,11 @@ class MessageRepository internal constructor(
      */
     private val retentionPeriodMs: Long? = null,
     private val clock: () -> Long = { System.currentTimeMillis() },
+    private val dao: MessageDao = database.messageDao(),
 ) {
 
-    private val dao = database.messageDao()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val temporaryId = AtomicLong(-1L)
 
     private val _entries = MutableStateFlow<List<MessageEntry>>(emptyList())
     val entries: StateFlow<List<MessageEntry>> = _entries.asStateFlow()
@@ -75,8 +78,7 @@ class MessageRepository internal constructor(
         RetentionPolicy.cutoff(clock(), retentionPeriodMs)
 
     fun addEntry(entry: MessageEntry) {
-        // Use negative timestamp as temporary id to avoid collision with auto-increment ids
-        val tempId = -entry.requestTimestamp
+        val tempId = temporaryId.getAndDecrement()
         val entryWithTempId = entry.copy(id = tempId)
 
         // Add to memory first for immediate UI update (applying TTL filter on the fly).

--- a/documentation/content/docs/ko/setup.mdx
+++ b/documentation/content/docs/ko/setup.mdx
@@ -9,8 +9,8 @@ description: Android 프로젝트에 Dari 추가하기
 
 ```kotlin
 dependencies {
-    debugImplementation("io.github.easyhooon:dari:1.5.0")
-    releaseImplementation("io.github.easyhooon:dari-noop:1.5.0")
+    debugImplementation("io.github.easyhooon:dari:1.5.1")
+    releaseImplementation("io.github.easyhooon:dari-noop:1.5.1")
 }
 ```
 

--- a/documentation/content/docs/setup.mdx
+++ b/documentation/content/docs/setup.mdx
@@ -9,8 +9,8 @@ Add the dependencies to your app module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    debugImplementation("io.github.easyhooon:dari:1.5.0")
-    releaseImplementation("io.github.easyhooon:dari-noop:1.5.0")
+    debugImplementation("io.github.easyhooon:dari:1.5.1")
+    releaseImplementation("io.github.easyhooon:dari-noop:1.5.1")
 }
 ```
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-dari = "1.5.0"
+dari = "1.5.1"
 agp = "9.0.0"
 coreKtx = "1.13.1"
 junit = "4.13.2"


### PR DESCRIPTION
## Summary

- generate repository-local temporary message IDs independently of request timestamps
- add deterministic regression coverage before and after each asynchronous ID reconciliation
- bump the library and setup documentation to 1.5.1

## Root Cause

Messages created in the same millisecond shared `-requestTimestamp` as their temporary ID. The first Room insert reconciliation replaced every matching entry with one persisted ID, producing duplicate list keys.

## Validation

- `./gradlew test ktlintCheck detekt :dari:connectedDebugAndroidTest`
- `npm run build` in `documentation`

Closes #76


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message handling to maintain unique IDs, including when messages share identical timestamps.
  * Improved reliability of message count updates and clearing operations.
* **Documentation**
  * Updated setup instructions to reference Dari version 1.5.1.
* **Chores**
  * Updated the project’s configured Dari version to 1.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->