### PR TITLE
chore: bump version to 1.6.0

### DIFF
--- a/documentation/content/docs/ko/setup.mdx
+++ b/documentation/content/docs/ko/setup.mdx
@@ -9,8 +9,8 @@ description: Android 프로젝트에 Dari 추가하기
 
 ```kotlin
 dependencies {
-    debugImplementation("io.github.easyhooon:dari:1.5.1")
-    releaseImplementation("io.github.easyhooon:dari-noop:1.5.1")
+    debugImplementation("io.github.easyhooon:dari:1.6.0")
+    releaseImplementation("io.github.easyhooon:dari-noop:1.6.0")
 }
 ```
 

--- a/documentation/content/docs/setup.mdx
+++ b/documentation/content/docs/setup.mdx
@@ -9,8 +9,8 @@ Add the dependencies to your app module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    debugImplementation("io.github.easyhooon:dari:1.5.1")
-    releaseImplementation("io.github.easyhooon:dari-noop:1.5.1")
+    debugImplementation("io.github.easyhooon:dari:1.6.0")
+    releaseImplementation("io.github.easyhooon:dari-noop:1.6.0")
 }
 ```
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-dari = "1.5.1"
+dari = "1.6.0"
 agp = "9.0.0"
 coreKtx = "1.13.1"
 junit = "4.13.2"


### PR DESCRIPTION
## Summary

- bump the Dari library artifacts from `1.5.1` to `1.6.0`
- update the English and Korean installation docs to use `1.6.0`
- follow up on the protobuf support merged in #81

## Validation

- `./gradlew check :sample:assembleDebug :sample:assembleRelease :dari:assembleRelease :dari-core:assembleRelease :dari-noop:assembleRelease`
- `npm run build` in `documentation/`