### PR TITLE
chore: bump version to 1.7.0

### DIFF
--- a/documentation/content/docs/ko/setup.mdx
+++ b/documentation/content/docs/ko/setup.mdx
@@ -9,8 +9,8 @@ description: Android 프로젝트에 Dari 추가하기
 
 ```kotlin
 dependencies {
-    debugImplementation("io.github.easyhooon:dari:1.6.0")
-    releaseImplementation("io.github.easyhooon:dari-noop:1.6.0")
+    debugImplementation("io.github.easyhooon:dari:1.7.0")
+    releaseImplementation("io.github.easyhooon:dari-noop:1.7.0")
 }
 ```
 

--- a/documentation/content/docs/setup.mdx
+++ b/documentation/content/docs/setup.mdx
@@ -9,8 +9,8 @@ Add the dependencies to your app module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    debugImplementation("io.github.easyhooon:dari:1.6.0")
-    releaseImplementation("io.github.easyhooon:dari-noop:1.6.0")
+    debugImplementation("io.github.easyhooon:dari:1.7.0")
+    releaseImplementation("io.github.easyhooon:dari-noop:1.7.0")
 }
 ```
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-dari = "1.6.0"
+dari = "1.7.0"
 agp = "9.0.0"
 coreKtx = "1.13.1"
 junit = "4.13.2"


### PR DESCRIPTION
## Summary
- bump Dari artifacts from 1.6.0 to 1.7.0
- update English and Korean setup documentation

## Verification
- ./gradlew check