### PR TITLE
ci: skip pages deploy on forks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && github.repository == 'easyhoooon/dari'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main' && github.repository == 'easyhoooon/dari'
+    if: github.ref == 'refs/heads/main' && github.repository == 'easyhooon/dari'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Context

I forked this repo to try contributing, and noticed the `docs.yml` workflow's `deploy` job runs automatically on every push/merge to `main` — including in forks. Since GitHub Pages isn't set up on a fork, `actions/deploy-pages` fails every time with:

```
Error: Failed to create deployment (status: 404) ...
Ensure GitHub Pages has been enabled
```

This means the Actions tab shows a permanent red ❌ on any fork, even when the actual change (and the `build` job that validates the docs) is completely fine. It also leaves failed deployment records under the contributor's own account, which isn't obviously related to the CI failure at a glance.

## Fix

Restrict the `deploy` job to only run on the upstream repo, so forks still get the useful signal (does the doc site build?) without attempting a deploy that's expected to fail.

```diff
  deploy:
    environment:
      name: github-pages
      url: ${{ steps.deployment.outputs.page_url }}
    runs-on: ubuntu-latest
    needs: build
-   if: github.ref == 'refs/heads/main'
+   if: github.ref == 'refs/heads/main' && github.repository == 'easyhooon/dari'
```

## Files Changed

- `.github/workflows/docs.yml` — added upstream-repo check to `deploy` job condition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted documentation deployments to the designated production repository and the `main` branch.
  * Prevented documentation deployment jobs from running in other repository contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->